### PR TITLE
Fix `wasm-ld` flags which require `=`

### DIFF
--- a/tests/all.rs
+++ b/tests/all.rs
@@ -101,3 +101,19 @@ fn main() {
     );
     assert_component(&output);
 }
+
+#[test]
+fn linker_flags() {
+    let output = compile(
+        &[
+            "-Clink-arg=--max-memory=65536",
+            "-Clink-arg=-zstack-size=32",
+            "-Clink-arg=--global-base=2048",
+        ],
+        r#"
+fn main() {
+}
+        "#,
+    );
+    assert_component(&output);
+}


### PR DESCRIPTION
I misunderstood flag parsing in `wasm-ld` and it looks like some flags require `=` for their values where for some it's optional and can be specified with a space instead. This implements distinguishing these arguments and then additionally rereads the `-help` page of `wasm-ld` and copies everything over.

Closes #22