### PR TITLE
Enable depending on this crate as a library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,7 +313,7 @@ impl FromStr for WasiAdapter {
     }
 }
 
-fn main() {
+pub fn main() {
     let err = match run() {
         Ok(()) => return,
         Err(e) => e,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,1 @@
+use wasm_component_ld::main;


### PR DESCRIPTION
Integration into rust-lang/rust for distributing this I'm planning to do with a Rust-level Cargo dependency on this crate to crates.io. To facilitate that move the contents of `src/main.rs` into `src/lib.rs` so this has a library that can be depended on.