### PR TITLE
Correct docs for default value of validation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,7 +279,7 @@ struct ComponentLdArgs {
 
     /// Whether or not the output component is validated.
     ///
-    /// This defaults to `true`.
+    /// This defaults to `false`.
     #[clap(long)]
     validate_component: Option<bool>,
 


### PR DESCRIPTION
It's off-by-default, not on-by-default.

Closes #97